### PR TITLE
Replace hvplot.scatter to hv.Scatter in a binded function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
     "dask>=2023.10.1",
     "datashader>=0.16.0",
     "spatialpandas>=0.4.9",
+    "pyinstrument>=4.6.0",
+    "snakeviz>=2.2.0",
+    "memray>=1.10.0",
 ]
 requires-python = ">=3.10,<3.13"
 readme = "README.md"

--- a/src/pfs_target_uploader/utils/io.py
+++ b/src/pfs_target_uploader/utils/io.py
@@ -196,7 +196,7 @@ def upload_file(
     # outfiles_dict["absname"].append(os.path.join(outdir, origname))
     # outfiles_dict["arcname"].append(os.path.join(outfile_zip_prefix, origname))
 
-    print(outfiles_dict)
+    # print(outfiles_dict)
 
     outdir, outfile_zip, sio = upload_write(
         outfiles_dict, outfile_zip_prefix, outdir, export=export

--- a/src/pfs_target_uploader/widgets/PppResultWidgets.py
+++ b/src/pfs_target_uploader/widgets/PppResultWidgets.py
@@ -74,6 +74,7 @@ class PppResultWidgets:
 
         # print(self.df_summary)
 
+        @pn.io.profile("update_alert")
         def update_alert(df):
             rot = np.ceil(df.iloc[-1]["Request time (h)"] * 10.0) / 10.0
             if rot > self.max_reqtime_normal:
@@ -84,6 +85,7 @@ class PppResultWidgets:
                 type = "success"
             return {"object": text, "alert_type": type}
 
+        @pn.io.profile("update_reqtime")
         def update_reqtime(df):
             rot = np.ceil(df.iloc[-1]["Request time (h)"] * 10.0) / 10.0
             if rot > self.max_reqtime_normal:
@@ -93,6 +95,7 @@ class PppResultWidgets:
                 c = "#3A7D7E"
             return {"value": rot, "default_color": c}
 
+        @pn.io.profile("update_summary_text")
         def update_summary_text(df):
             rot = np.ceil(df.iloc[-1]["Request time (h)"] * 10.0) / 10.0
             n_ppc = df.iloc[-1]["N_ppc"]
@@ -120,6 +123,7 @@ class PppResultWidgets:
             )
             return {"object": text}
 
+        @pn.io.profile("stream_export_files")
         def stream_export_files(df_psl, df_ppc, p_fig):
             _, outfile_zip, sio = upload_file(
                 self.df_input,


### PR DESCRIPTION
It seems that hvplot.scatter() is much slower than holoviews.Scatter(). I tried to replace the former to the latter in the callback function in plot_ppc. From the profiling, the rendering appears to be faster. Still, response is not super fast. I'm not sure if we can make "pipelined_call" to be faster.