### PR TITLE
update overheads

### DIFF
--- a/docs/docs/PPP.md
+++ b/docs/docs/PPP.md
@@ -152,11 +152,15 @@ Transparent <span style="color: grey;">gray</span> hexagons show the PFS FoV at 
 
 In the PPP calculation, the following parameters are fixed.
 
-| Description                           | Value | Unit |
-|---------------------------------------|------:|------|
-| Number of fibers                      |  2394 |      |
-| Number of calibrators                 |   200 |      |
-| Fiber configuration time per exposure |   180 | s    |
-| Miscellaneous overheads               |    60 | s    |
-| Maximum PPP running time              |   900 | s    |
-| Maximum number of pointings           |   200 |      |
+| Description                           | Value | Unit    |
+|---------------------------------------|------:|---------|
+| Number of fibers                      |  2394 |         |
+| Number of calibrators                 |   200 |         |
+| Fiber configuration time per exposure |   180 | s       |
+| Miscellaneous overheads[^1]           |   120 | s       |
+| Calibration overheads[^2]             |   1.2 | h/night |
+| Maximum PPP running time              |   900 | s       |
+| Maximum number of pointings           |   200 |         |
+
+[^1]: Overhead time charged for individual exposure such as readout, slew the telescope, field acquisition, and guide star acquisition.
+[^2]: Overhead time to obtain calibration data. Current best estimate is 1.2 h per night. That is, 1.2 h is charged for each 8.8 h individual exposures.

--- a/docs/docs/PPP.md
+++ b/docs/docs/PPP.md
@@ -163,4 +163,4 @@ In the PPP calculation, the following parameters are fixed.
 | Maximum number of pointings           |   200 |         |
 
 [^1]: Overhead time charged for individual exposure such as readout, slew the telescope, field acquisition, and guide star acquisition.
-[^2]: Overhead time to obtain calibration data. Current best estimate is 1.2 h per night. That is, 1.2 h is charged for each 8.8 h individual exposures.
+[^2]: Overhead time to obtain calibration data. Current best estimate is 1.2 h per night. That is, 1.2 h is charged for every 8.8 h individual exposures.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -57,6 +57,7 @@ markdown_extensions:
   - attr_list
   - def_list
   - md_in_html
+  - footnotes
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.arithmatex:

--- a/src/pfs_target_uploader/utils/ppp.py
+++ b/src/pfs_target_uploader/utils/ppp.py
@@ -1130,15 +1130,32 @@ def ppp_result(
         )
 
     def overheads(n_sci_frame):
+
+        t_night_hours: float = 10.0  # [h] total observing time per night
+
         # in seconds
         # t_exp_sci: float = 900.0
-        t_exp_sci: float = single_exptime
-        t_overhead_misc: float = 60.0
-        t_overhead_fiber: float = 180.0
+        t_exp_sci: float = single_exptime  # [s]
 
-        Toverheads_tot_best = (
+        t_overhead_misc: float = 120.0  # [s] miscellanous overheads
+        t_overhead_fiber: float = 180.0  # [s] fiber reconfiguration overheads
+
+        t_overhead_shared_hours: float = 1.2  # [h] calibrations per night
+
+        # [s] total time for all pointings
+        t_total_pointings = (
             t_exp_sci + t_overhead_misc + t_overhead_fiber
         ) * n_sci_frame
+
+        # [s] overheads for the program
+        t_overhead_program = (
+            t_total_pointings
+            / (t_night_hours - t_overhead_shared_hours)
+            * t_overhead_shared_hours
+        )
+
+        # [s] total request observing time (ROT)
+        Toverheads_tot_best = t_total_pointings + t_overhead_program
 
         return Toverheads_tot_best / 3600.0
 


### PR DESCRIPTION
- 3 min for fiber configuration
- 2 min for other overhead
- 1.2 h/n (or every 8.8h)
- documentation update
