### PR TITLE
fix pyproject.toml to avoid errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,9 +120,9 @@ gen-requirements = { cmd = [
 ], help = "Generate requirements.txt" }
 
 
-[tool.pdm.options]
-add = ["--no-isolation"]
-install = ["--no-isolation"]
+# [tool.pdm.options]
+# add = ["--no-isolation"]
+# install = ["--no-isolation"]
 
 [tool.ruff]
 target-version = "py39"
@@ -149,6 +149,7 @@ ignore = [
 
 [tool.black]
 line-length = 88
+target-version = ["py39", "py310", "py311"]
 
 # [tool.pdm.options]
 # add = ["--no-isolation", "--no-self"]


### PR DESCRIPTION
It seems that the `--no-isolation` option causes an error. This commit fixes it. 